### PR TITLE
API Enhancements

### DIFF
--- a/src/componentMapper.tsx
+++ b/src/componentMapper.tsx
@@ -1,4 +1,4 @@
-import { Fields, objectMapper, ObjectMapperOptions } from './objectMapper';
+import { Fields, ObjectMapperOptions, objectMapper } from './objectMapper';
 import React from 'react';
 
 /**

--- a/src/componentMapper.tsx
+++ b/src/componentMapper.tsx
@@ -1,4 +1,4 @@
-import { Fields, objectMapper } from './objectMapper';
+import { Fields, objectMapper, ObjectMapperOptions } from './objectMapper';
 import React from 'react';
 
 /**
@@ -17,10 +17,10 @@ import React from 'react';
  * @param fields
  */
 export function componentMapper<Props = any>
-	(Component: React.ComponentType<any>, fields: Fields): React.ComponentType<Props> {
+	(Component: React.ComponentType<any>, fields: Fields, options?: ObjectMapperOptions): React.ComponentType<Props> {
 
 	return (props: any) => {
-		const newProps: Props = objectMapper(props, fields);
+		const newProps: Props = objectMapper(props, fields, options);
 		return <Component {...newProps} />;
 	};
 }

--- a/src/objectMapper.ts
+++ b/src/objectMapper.ts
@@ -8,16 +8,26 @@ export interface FieldsInternal {
 	[src: string]: ObjectMapperField;
 }
 
+export interface ObjectMapperOptions {
+	rest?: boolean;
+	ignore?: string[];
+}
 /**
  * Example 1:
  *
  * mapObject({ foo: 'bar' })
  */
+export function objectMapper(obj: any, fields: Fields, options?: ObjectMapperOptions) {
+	const { ignore, rest }: ObjectMapperOptions = {
+		ignore: [],
+		rest: false,
+		...options,
+	};
 
-export function objectMapper(obj: any, fields: Fields) {
 	const newObj: any = {};
-	// const processedFields = processMapperFields(fields);
+	const restObj: any = {};
 
+	// Do the mapping magic here
 	Object.keys(fields).forEach(destKey => {
 		const src = fields[destKey];
 
@@ -38,7 +48,21 @@ export function objectMapper(obj: any, fields: Fields) {
 		newObj[destKey] = value;
 	});
 
-	return newObj;
+	// Find rest props
+	if (rest === true) {
+		const inputKeys = Object.values(fields).filter(x => typeof x === 'string');
+
+		Object.keys(obj).forEach(key => {
+			if (inputKeys.indexOf(key) < 0 && ignore.indexOf(key) < 0) {
+				restObj[key] = obj[key];
+			}
+		});
+	}
+
+	return {
+		...restObj,
+		...newObj,
+	};
 }
 
 export type foo = Partial<Fields>;

--- a/src/objectMapper.ts
+++ b/src/objectMapper.ts
@@ -1,26 +1,11 @@
-export interface ObjectMapperField {
-	key?: string;
-	transform?: (...params: any[]) => any;
-}
+export type ObjectMapperField = string | ((...params: any[]) => any);
 
 export interface Fields {
-	[src: string]: string | ObjectMapperField;
+	[src: string]: ObjectMapperField;
 }
 
 export interface FieldsInternal {
 	[src: string]: ObjectMapperField;
-}
-
-function processMapperFields(fields: Fields): FieldsInternal {
-	const newFields: FieldsInternal = {};
-
-	Object.keys(fields).forEach((srcKey: string) => {
-		const destKey = fields[srcKey];
-
-		newFields[srcKey] = typeof destKey === 'string' ? { key: destKey } : destKey;
-	});
-
-	return newFields;
 }
 
 /**
@@ -31,19 +16,19 @@ function processMapperFields(fields: Fields): FieldsInternal {
 
 export function objectMapper(obj: any, fields: Fields) {
 	const newObj: any = {};
-	const processedFields = processMapperFields(fields);
+	// const processedFields = processMapperFields(fields);
 
-	Object.keys(processedFields).forEach(destKey => {
-		const src = processedFields[destKey];
+	Object.keys(fields).forEach(destKey => {
+		const src = fields[destKey];
 
 		let value;
 
-		if (src.key && obj[src.key]) {
-			value = obj[src.key];
+		if (typeof src === 'string' && obj[src]) {
+			value = obj[src];
 		}
 
-		if (src.transform) {
-			value = src.transform(obj, fields);
+		if (typeof src === 'function' && src) {
+			value = src(obj, fields);
 		}
 
 		if (value === undefined) {

--- a/src/tests/componentMapper.test.tsx
+++ b/src/tests/componentMapper.test.tsx
@@ -22,12 +22,8 @@ describe('componentMapper', () => {
 		const Button: React.ComponentType<ButtonProps> = componentMapper(ThirdPartyButton, {
 			children: 'children',
 			disabled: 'disabled',
-			mini: {
-				transform: (props: ButtonProps) => props.size === 'small'
-			},
-			primary: {
-				transform: (props: ButtonProps) => props.color === 'primary'
-			},
+			mini: (props: ButtonProps) => props.size === 'small',
+			primary: (props: ButtonProps) => props.color === 'primary',
 		});
 
 		const rendered = TestRenderer.create(

--- a/src/tests/objectMapper.test.ts
+++ b/src/tests/objectMapper.test.ts
@@ -37,6 +37,9 @@ describe('Utils', () => {
 			// External lib has an onClick event, that send required value on param.target
 			// Our internal api understands onPress event, with value in param.value
 			const src = {
+				baz: 'bar',
+				foo: false,
+				hello: 'world',
 				label: 'Submit',
 				onClick: (event: any) => `${event.target} Clicks`,
 			};
@@ -49,10 +52,14 @@ describe('Utils', () => {
 				},
 			};
 
-			const output = objectMapper(src, fields);
+			const output = objectMapper(src, fields, { rest: true, ignore: ['hello'] });
 
 			expect(output.children).toBe('Submit');
 			expect(output.onPress({ value: 5 })).toBe('5 Clicks');
+
+			// Rest
+			expect(output.baz).toBe('bar');
+			expect(output.foo).toBe(false);
 		});
 	});
 });

--- a/src/tests/objectMapper.test.ts
+++ b/src/tests/objectMapper.test.ts
@@ -43,12 +43,9 @@ describe('Utils', () => {
 
 			const fields = {
 				children: 'label',
-				onPress: {
-					key: 'onClick',
-					transform: (props: typeof src) => {
-						// Return a onPress function
-						return (onPressParam: any) => props.onClick({ target: onPressParam.value });
-					},
+				onPress: (props: typeof src) => {
+					// Return a onPress function
+					return (onPressParam: any) => props.onClick({ target: onPressParam.value });
 				},
 			};
 


### PR DESCRIPTION
- Mapper fields can now be thunks
- Mapper functions now accept a third param `options`. This is an object with the following keys:
  - `rest` (boolean): if `true`, unmapped props will be transferred as is.
  - `ignore` (string[]): list of key to ignore in the rest object